### PR TITLE
Fix broken nested list rendering in Malware.md due to insufficient indentation

### DIFF
--- a/docs/Rules/Malware.md
+++ b/docs/Rules/Malware.md
@@ -29,13 +29,13 @@ Build a single Windows EXE that runs unattended (no UI, no arguments). Your prog
 
 1. Registry: `answer_1` in `HKLM:\SOFTWARE\BOMBE`
 2. Encrypted SQLite database: `C:\Users\bombe\AppData\Local\bhrome\Login Data`
-   - Decrypt `password_value` using AES-CBC with your `secret` as the key
-   - Convert the `secret` (length 32) literal to bytes directly as the AES key (not hex)
-     - Example (Python): `key = "9nnv7xxZQpmialMXSgAb3YV0bhQstxF0".encode()`
-   - `password_value` is hex-encoded
-     - Example (Python): `password = bytes.fromhex(password_value)`
-   - `password_value` = IV(16 bytes) + ciphertext
-     - Example (Python): `iv, cipher = password[:16], password[16:]`
+    - Decrypt `password_value` using AES-CBC with your `secret` as the key
+    - Convert the `secret` (length 32) literal to bytes directly as the AES key (not hex)
+        - Example (Python): `key = "9nnv7xxZQpmialMXSgAb3YV0bhQstxF0".encode()`
+    - `password_value` is hex-encoded
+        - Example (Python): `password = bytes.fromhex(password_value)`
+    - `password_value` = IV(16 bytes) + ciphertext
+        - Example (Python): `iv, cipher = password[:16], password[16:]`
 3. Memory of the specified process: `bsass.exe`
 
 SQLite table schema:


### PR DESCRIPTION
## Description
This PR fixes a rendering issue in `docs/Rules/Malware.md` where the nested list items under "2. Encrypted SQLite database" were incorrectly rendered as top-level numbered items (3, 4, 5, etc.) instead of bullet points.

## Issue
MkDocs (and standard Python-Markdown) typically requires a 4-space indentation for nested lists to be recognized correctly. The previous version used 3 spaces, causing the parser to break the list continuity.

## Changes
- Adjusted indentation from 3 spaces to 4 spaces for the first level of nesting.
- Adjusted indentation for the code examples (second level) to align correctly (8 spaces).

## Visuals
**Before (Broken rendering):**
<img width="695" height="400" alt="image" src="https://github.com/user-attachments/assets/092b0736-37a2-4b3e-b0d1-99a847d24fd2" />

**After (Fixed rendering):**
<img width="667" height="411" alt="image" src="https://github.com/user-attachments/assets/d7595d01-6397-4547-a985-633a773d1510" />

## References
- **Python-Markdown Rules**: The underlying parser for MkDocs strictly follows the original Markdown syntax which requires 4-space indentation for nested blocks. (See [Python-Markdown Issue #3](https://github.com/Python-Markdown/markdown/issues/3))
- **Standard Syntax**: "Each subsequent paragraph in a list item must be indented by either 4 spaces or one tab." - [Daring Fireball](https://daringfireball.net/projects/markdown/syntax#list)